### PR TITLE
Add logic to download URL for ZK >= 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Parameters:
 * `version`: Version of ZooKeeper to install
 * `username`: The user who will eventually run Zookeeper (default: `'zookeeper'`)
 * `user_home`: Path to the home folder for the Zookeeper user (default: `/home/zookeeper`)
-* `mirror`: The mirror to obtain ZooKeeper from (required)
+* `mirror`: The base URL to obtain ZooKeeper from (default: `'http://archive.apache.org/dist/zookeeper'`)
 * `checksum`: Checksum for the ZooKeeper download file
 * `install_dir`: Which directory to install Zookeeper to (default: `'/opt/zookeeper'`)
 * `java_version`: The version of OpenJDK to install.
@@ -48,11 +48,11 @@ Parameters:
 
 Example:
 
-``` ruby
+```ruby
 zookeeper 'zookeeper' do
   version  '3.4.8'
   username 'zookeeper'
-  mirror   'http://www.poolsaboveground.com/apache/zookeeper'
+  mirror   'http://archive.apache.org/dist/zookeeper'
   checksum 'f10a0b51f45c4f64c1fe69ef713abf9eb9571bc7385a82da892e83bb6c965e90'
   action   :install
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :version,             String, default: '3.6.1'
-property :mirror,              String, default: 'http://archive.apache.org/dist/zookeeper/'
+property :mirror,              String, default: 'http://archive.apache.org/dist/zookeeper'
 property :checksum,            String
 property :username,            String, default: 'zookeeper'
 property :user_home,           String, default: '/home/zookeeper'
@@ -53,8 +53,14 @@ action :install do
     recursive true
   end
 
+  artifact = if Gem::Requirement.new('>= 3.5.0').satisfied_by? Gem::Version.new(new_resource.version)
+               "apache-zookeeper-#{new_resource.version}-bin.tar.gz"
+             else
+               "zookeeper-#{new_resource.version}.tar.gz"
+             end
+
   ark 'zookeeper' do
-    url         "#{new_resource.mirror}/zookeeper-#{new_resource.version}/apache-zookeeper-#{new_resource.version}-bin.tar.gz"
+    url         "#{new_resource.mirror}/zookeeper-#{new_resource.version}/#{artifact}"
     version     new_resource.version
     prefix_root new_resource.install_dir
     prefix_home new_resource.install_dir

--- a/spec/unit/resources/zookeeper_spec.rb
+++ b/spec/unit/resources/zookeeper_spec.rb
@@ -15,4 +15,19 @@ describe 'zookeeper' do
 
     it { is_expected.to install_ark('zookeeper') }
   end
+
+  context 'with pre-3.5.0 version' do
+    recipe do
+      zookeeper 'zookeeper' do
+        version '3.4.9'
+        use_java_cookbook false
+      end
+    end
+
+    it do
+      is_expected.to install_ark('zookeeper').with(
+        url: 'http://archive.apache.org/dist/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz'
+      )
+    end
+  end
 end


### PR DESCRIPTION
Per evertrue/zookeeper-cookbook#229, the tarball changed naming scheme as of ZooKeeper v3.5.0.

Not sure how this cookbook has continued to work but this should definitely fix things.

H/t to @mgrenoville & @MEDIARITHMICS for pointing this out & their code.